### PR TITLE
Replace SDL_GetWindowSize by SDL_GL_GetDrawableSize to support HDPI mode

### DIFF
--- a/src/renderer_GL_common.inl
+++ b/src/renderer_GL_common.inl
@@ -1051,7 +1051,7 @@ static GPU_Target* CreateTargetFromWindow(GPU_Renderer* renderer, Uint32 windowI
     }
     
     // Store the window info
-    SDL_GetWindowSize(window, &target->context->window_w, &target->context->window_h);
+    SDL_GL_GetDrawableSize(window, &target->context->window_w, &target->context->window_h);
     target->context->stored_window_w = target->context->window_w;
     target->context->stored_window_h = target->context->window_h;
     target->context->windowID = SDL_GetWindowID(window);
@@ -1444,7 +1444,7 @@ static void MakeCurrent(GPU_Renderer* renderer, GPU_Target* target, Uint32 windo
             window = SDL_GetWindowFromID(windowID);
             if(window != NULL)
             {
-                SDL_GetWindowSize(window, &target->context->window_w, &target->context->window_h);
+                SDL_GL_GetDrawableSize(window, &target->context->window_w, &target->context->window_h);
                 target->base_w = target->context->window_w;
                 target->base_h = target->context->window_h;
             }
@@ -1542,11 +1542,11 @@ static Uint8 SetWindowResolution(GPU_Renderer* renderer, Uint16 w, Uint16 h)
 #ifdef SDL_GPU_USE_SDL2
     
     // Don't need to resize (only update internals) when resolution isn't changing.
-    SDL_GetWindowSize(SDL_GetWindowFromID(target->context->windowID), &target->context->window_w, &target->context->window_h);
+    SDL_GL_GetDrawableSize(SDL_GetWindowFromID(target->context->windowID), &target->context->window_w, &target->context->window_h);
     if(target->context->window_w != w || target->context->window_h != h)
     {
         SDL_SetWindowSize(SDL_GetWindowFromID(target->context->windowID), w, h);
-        SDL_GetWindowSize(SDL_GetWindowFromID(target->context->windowID), &target->context->window_w, &target->context->window_h);
+        SDL_GL_GetDrawableSize(SDL_GetWindowFromID(target->context->windowID), &target->context->window_w, &target->context->window_h);
     }
     
 #else
@@ -1690,7 +1690,7 @@ static Uint8 SetFullscreen(GPU_Renderer* renderer, Uint8 enable_fullscreen, Uint
             SDL_SetWindowSize(SDL_GetWindowFromID(target->context->windowID), target->context->stored_window_w, target->context->stored_window_h);
         
         // Update window dims
-        SDL_GetWindowSize(SDL_GetWindowFromID(target->context->windowID), &target->context->window_w, &target->context->window_h);
+        SDL_GL_GetDrawableSize(SDL_GetWindowFromID(target->context->windowID), &target->context->window_w, &target->context->window_h);
     }
     
 #else


### PR DESCRIPTION
Hi,

I am not a big fan of github, but since you are there now, I thought it would be easier to make a pull-request than mail directly. I ran into a display issue when creating a SDL_Windows with SDL_WINDOW_ALLOW_HIGHDPI flag set on HDPI screens. Such windows have different drawable and window sizes, which results in incomplete window viewport (basically only 1/4 bottom left area is covered). A solution is to use https://wiki.libsdl.org/SDL_GL_GetDrawableSize for the dimensions and it worked out of the box for our users.

I cannot say I tested it very carefully, because I do not have such a screen. Moreover, this patch currently breaks SDL-2.0.0 compatibility (which is almost two years old), I can imagine recovering it by a simple define but the necessity of such an action is to be discussed. Perhaps, it should be reviewed by somebody else before merging.

Vit ;)