### PR TITLE
Added convenience function GPU_LinkManyShaders().

### DIFF
--- a/include/SDL_gpu.h
+++ b/include/SDL_gpu.h
@@ -1456,6 +1456,9 @@ DECLSPEC Uint32 SDLCALL GPU_LoadShader(GPU_ShaderEnum shader_type, const char* f
 /*! Creates and links a shader program with the given shader objects. */
 DECLSPEC Uint32 SDLCALL GPU_LinkShaders(Uint32 shader_object1, Uint32 shader_object2);
 
+/*! Creates and links a shader program with the given shader objects. */
+DECLSPEC Uint32 SDLCALL GPU_LinkManyShaders(Uint32 *shader_objects, int count);
+
 /*! Deletes a shader object. */
 DECLSPEC void SDLCALL GPU_FreeShader(Uint32 shader_object);
 

--- a/src/SDL_gpu.c
+++ b/src/SDL_gpu.c
@@ -1846,7 +1846,16 @@ Uint32 GPU_CreateShaderProgram(void)
 
 Uint32 GPU_LinkShaders(Uint32 shader_object1, Uint32 shader_object2)
 {
+    Uint32 shaders[2];
+    shaders[0] = shader_object1;
+    shaders[1] = shader_object2;
+    return GPU_LinkManyShaders(shaders, 2);
+}
+
+Uint32 GPU_LinkManyShaders(Uint32 *shader_objects, int count)
+{
     Uint32 p;
+    int i;
 
     if(_gpu_current_renderer == NULL || _gpu_current_renderer->current_context_target == NULL)
         return 0;
@@ -1856,8 +1865,8 @@ Uint32 GPU_LinkShaders(Uint32 shader_object1, Uint32 shader_object2)
 
     p = _gpu_current_renderer->impl->CreateShaderProgram(_gpu_current_renderer);
 
-    _gpu_current_renderer->impl->AttachShader(_gpu_current_renderer, p, shader_object1);
-    _gpu_current_renderer->impl->AttachShader(_gpu_current_renderer, p, shader_object2);
+    for (i = 0; i < count; i++)
+        _gpu_current_renderer->impl->AttachShader(_gpu_current_renderer, p, shader_objects[i]);
 
     if(_gpu_current_renderer->impl->LinkShaderProgram(_gpu_current_renderer, p))
         return p;


### PR DESCRIPTION
GPU_LinkManyShaders() does the same thing as GPU_LinkShaders(), but takes an array and a size. This patch also implements GPU_LinkShaders() in terms of GPU_LinkManyShaders().