### PR TITLE
Install includes to include/SDL2 when building against SDL2.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,7 +153,11 @@ source_group(Common FILES ${SDL_gpu_SRCS} ${SDL_gpu_HDRS})
 
 # Install the headers and library
 if(SDL_gpu_INSTALL)
-	install(FILES ${SDL_gpu_install_HDRS} DESTINATION include/SDL)
+	if(SDL_gpu_USE_SDL1)
+		install(FILES ${SDL_gpu_install_HDRS} DESTINATION include/SDL)
+	else(SDL_gpu_USE_SDL1)
+		install(FILES ${SDL_gpu_install_HDRS} DESTINATION include/SDL2)
+	endif(SDL_gpu_USE_SDL1)
 
 	if(SDL_gpu_BUILD_SHARED)
 		install(TARGETS SDL_gpu_shared EXPORT SDL_gpu-targets DESTINATION lib)


### PR DESCRIPTION
Installing to include/SDL makes life difficult on systems that
have both SDL and SDL2 headers installed, as you must make sure
to get -I/usr/include/SDL2 earlier on the command line than
-I/usr/include/SDL or you will get random runtime crashes because
you've compiled against the wrong SDL headers.