### PR TITLE
Fix the reference to GLES3/gl3ext.h

### DIFF
--- a/include/SDL_gpu_GLES_3.h
+++ b/include/SDL_gpu_GLES_3.h
@@ -11,7 +11,7 @@
     #include <OpenGLES/ES3/glext.h>
 #else
     #include "GLES3/gl3.h"
-    #include "GLES3/gl3ext.h"
+    #include "GLES2/gl2ext.h"
 #endif
 
 	#define glVertexAttribI1i glVertexAttrib1f


### PR DESCRIPTION
Fix the reference to GLES3/gl3ext.h to point to GLES2/gl2ext.h - the former is only provided for backwards compatibility, while the latter is the correct header.

See https://www.khronos.org/registry/OpenGL/index_es.php

My platform (Odroid XU4/Ubuntu) doesn't have gl3ext.h.