### PR TITLE
Fix use of SDL_Color in SDL1

### DIFF
--- a/src/renderer_GL_common.inl
+++ b/src/renderer_GL_common.inl
@@ -4987,10 +4987,9 @@ static void TriangleBatchX(GPU_Renderer* renderer, GPU_Image* image, GPU_Target*
             else
             {
                 SDL_Color color = get_complete_mod_color(renderer, target, image);
-                #if SDL_MAJOR_VERSION > 1
+                #if SDL_GPU_USE_SDL2
                 float default_color[4] = {color.r/255.0f, color.g/255.0f, color.b/255.0f, color.a/255.0f};
                 #else
-		// SDL1's SDL_Color does not have a .a property. Use unused instead.
                 float default_color[4] = {color.r/255.0f, color.g/255.0f, color.b/255.0f, color.unused/255.0f};
                 #endif
                 SetAttributefv(renderer, context->current_shader_block.color_loc, 4, default_color);

--- a/src/renderer_GL_common.inl
+++ b/src/renderer_GL_common.inl
@@ -4987,11 +4987,7 @@ static void TriangleBatchX(GPU_Renderer* renderer, GPU_Image* image, GPU_Target*
             else
             {
                 SDL_Color color = get_complete_mod_color(renderer, target, image);
-                #if SDL_GPU_USE_SDL2
-                float default_color[4] = {color.r/255.0f, color.g/255.0f, color.b/255.0f, color.a/255.0f};
-                #else
-                float default_color[4] = {color.r/255.0f, color.g/255.0f, color.b/255.0f, color.unused/255.0f};
-                #endif
+                float default_color[4] = {color.r/255.0f, color.g/255.0f, color.b/255.0f, GET_ALPHA(color)/255.0f};
                 SetAttributefv(renderer, context->current_shader_block.color_loc, 4, default_color);
             }
         }

--- a/src/renderer_GL_common.inl
+++ b/src/renderer_GL_common.inl
@@ -4987,7 +4987,12 @@ static void TriangleBatchX(GPU_Renderer* renderer, GPU_Image* image, GPU_Target*
             else
             {
                 SDL_Color color = get_complete_mod_color(renderer, target, image);
+                #if SDL_MAJOR_VERSION > 1
                 float default_color[4] = {color.r/255.0f, color.g/255.0f, color.b/255.0f, color.a/255.0f};
+                #else
+		// SDL1's SDL_Color does not have a .a property. Use unused instead.
+                float default_color[4] = {color.r/255.0f, color.g/255.0f, color.b/255.0f, color.unused/255.0f};
+                #endif
                 SetAttributefv(renderer, context->current_shader_block.color_loc, 4, default_color);
             }
         }


### PR DESCRIPTION
[SDL_Color in SDL1](https://www.libsdl.org/release/SDL-1.2.15/docs/html/sdlcolor.html) does not have a `.a` property. Switch it to `.unused` when in SDL1.