### PR TITLE
GLSL fixes

### DIFF
--- a/demos/data/shaders/alpha_mask.frag
+++ b/demos/data/shaders/alpha_mask.frag
@@ -1,7 +1,7 @@
 
-in vec4 color;
-in vec2 texCoord;
-out vec4 fragColor;
+varying vec4 color;
+varying vec2 texCoord;
+#define fragColor gl_FragColor
 
 uniform sampler2D tex;
 uniform sampler2D mask_tex;

--- a/demos/data/shaders/marching_ants.frag
+++ b/demos/data/shaders/marching_ants.frag
@@ -1,7 +1,7 @@
 
-in vec4 color;
-in vec2 texCoord;
-out vec4 fragColor;
+varying vec4 color;
+varying vec2 texCoord;
+#define fragColor gl_FragColor
 
 uniform sampler2D tex;
 


### PR DESCRIPTION
Here is the error I was getting:
``Failed to load fragment shader (data/shaders/alpha_mask.frag): 0:3(1): error: `in' qualifier in declaration of `color' only valid for function parameters in GLSL 1.20
0:4(1): error: `in' qualifier in declaration of `texCoord' only valid for function parameters in GLSL 1.20
0:5(1): error: `out' qualifier in declaratio
Failed to load fragment shader (data/shaders/marching_ants.frag): 0:3(1): error: `in' qualifier in declaration of `color' only valid for function parameters in GLSL 1.20
0:4(1): error: `in' qualifier in declaration of `texCoord' only valid for function parameters in GLSL 1.20
0:5(1): error: `out' qualifier in declaratio``

Before fix:
![beforefix](https://user-images.githubusercontent.com/33639078/36634676-0f869d08-1976-11e8-98dd-202ce3ff7cfb.png)

After fix:
![afterfix](https://user-images.githubusercontent.com/33639078/36634678-14fa6760-1976-11e8-8c28-2f1ddf75f921.png)

Am I using SDL_gpu incorrectly? It seems to be hard-coded in the .h files which GLSL version the files are, and reverting from in to varying (as per the `#version 100`) fixed the errors.

Really enjoying what this library has to offer. Keep up the great work!