### PR TITLE
Fix common crash on Android after GLContext reinit

### DIFF
--- a/src/renderer_GL_common.inl
+++ b/src/renderer_GL_common.inl
@@ -3911,7 +3911,7 @@ static void FreeImage(GPU_Renderer* renderer, GPU_Image* image)
     }
     else
     {
-        if(data->owns_handle)
+        if(data->owns_handle && image->renderer == GPU_GetCurrentRenderer())
         {
             GPU_MakeCurrent(image->context_target, image->context_target->context->windowID);
             glDeleteTextures( 1, &data->handle);


### PR DESCRIPTION
Hi @grimfang4, thanks for SDL-gpu!

We're using SDL-gpu primarily for Android, which has a bunch of unfortunate quirks as I'm sure you might be aware. The one in question is that Android likes to destroy the GLContext at every opportunity (e.g. when entering the task switcher).

This means:

a) We have to reinit entirely via `GPU_Init` to get a valid `GPU_Renderer` again
b) Rendering `GPU_Image`s uploaded into the previous GLContext fails, so we have to recreate them from the source PNGs (etc.)

If our logic is clever enough to catch Android while it's destroying the GLContext, we could deinit most of our `GPU_Image`s at that point too, but this isn't always possible / desirable. Instead, we try to reinit our textures while rendering with the new context. This is maybe not entirely efficient but it means we're making no assumptions and is therefore "correct".

The problem is, if we try to call `GPU_FreeImage` on a `GPU_Image` inited with a renderer that has since been destroyed, we get a General Protection Fault in the line after the one I've updated in this PR, because context_target is now a garbage pointer. All the preceding safety checks pass, because we _have_ a renderer, just not the right one.

So this just ensures the renderer is current before trying to do something impossible. I'd be curious to hear your thoughts about this. Maybe there's a better place to do this check, or to clean up the GPU_Images – ideally the renderer would know about all of its GPU_Images in some way and recursively "free" them when it is freed. But that'd be a major overhaul from what I could gather.

I was concerned about memory leaks with this, but it seems that the GPU memory itself is cleaned up when the context is killed anyway, so I couldn't see any leaks associated with this change.