### PR TITLE
Fix camera matrix multiplication order (again?)

### DIFF
--- a/src/renderer_GL_common.inl
+++ b/src/renderer_GL_common.inl
@@ -4814,10 +4814,12 @@ static void gpu_upload_modelviewprojection(GPU_Target* dest, GPU_Context* contex
         
         if(dest->use_camera)
         {
+            float temp[16];
             float cam_matrix[16];
             get_camera_matrix(cam_matrix);
-            
-            GPU_MultiplyAndAssign(mvp, cam_matrix);
+
+            GPU_MatrixMultiply(temp, cam_matrix, mvp);
+            GPU_MatrixCopy(mvp, temp);
         }
         
         glUniformMatrix4fv(context->current_shader_block.modelViewProjection_loc, 1, 0, mvp);


### PR DESCRIPTION
Commit https://github.com/grimfang4/sdl-gpu/commit/d4a4b39e7defb2ff9728373d5f204d1dbe486a90 breaks our existing code, because the "fixed" order fails to scale the translate component of our MV matrices. So after the transforms we end up with a MVP matrix that looks something like this:

|   |  |  |   |
| ---- | ---- | ---- | ---- |
| tiny | 0 | 0 | 0 |
| 0 | tiny | 0 | 0 |
| 0 | 0 | tiny | 0 |
| huge | huge | 0 | 1 |

... meaning all of our content is presumably rendered perfectly, but hundreds of screen-widths away.

The issue doesn't occur in the old version, or when we reverse the order of the matrix multiplication, as in this PR. Not sure if the old version was causing bugs, but we certainly get a blank screen on the latest master without the change in this PR.