### PR TITLE
Let SDL_gpu repo be easily added as a dependency in a CMake project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
 CMakeCache.txt
 CMakeFiles
 Makefile
+build/
 *.cmake
 *-demo
 *-test
 *.a
 *.so
 *.o
-
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ option(BUILD_DEMOS "Build SDL_gpu demo programs" ${DEFAULT_BUILD_DEMOS})
 option(BUILD_TESTS "Build SDL_gpu test programs" OFF)
 option(BUILD_VIDEO_TEST "Build SDL_gpu video test program (requires FFMPEG)" OFF)
 option(BUILD_TOOLS "Build SDL_gpu tool programs" OFF)
+option(BUILD_DOCS "Build SDL_gpu documentation" OFF)
 option(USE_SDL1 "Use SDL 1.2 headers and library instead of SDL 2" OFF)
 option(DISABLE_OPENGL "Disable OpenGL renderers.  Overrides specific OpenGL renderer flags." ${DEFAULT_DISABLE_OPENGL})
 option(DISABLE_GLES "Disable OpenGLES renderers.  Overrides specific GLES renderer flags." ${DEFAULT_DISABLE_GLES})
@@ -323,16 +324,18 @@ if(NOT STBI_FOUND OR NOT STBI_WRITE_FOUND)
 endif(NOT STBI_FOUND OR NOT STBI_WRITE_FOUND)
 
 # add a target to generate API documentation with Doxygen
-find_package(Doxygen)
-if(DOXYGEN_FOUND)
-    set(DOXYGEN_INPUT ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/src)
-    configure_file(${CMAKE_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
-    add_custom_target(doc
-        ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        COMMENT "Generating API documentation with Doxygen" VERBATIM
-    )
-endif(DOXYGEN_FOUND)
+if (BUILD_DOCS)
+    find_package(Doxygen)
+    if(DOXYGEN_FOUND)
+        set(DOXYGEN_INPUT ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/src)
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
+        add_custom_target(doc
+    `        ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            COMMENT "Generating API documentation with Doxygen" VERBATIM
+        )
+    endif(DOXYGEN_FOUND)
+endif (BUILD_DOCS)
 
 add_definitions("-Wall -pedantic")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,8 +110,8 @@ foreach(INC_FILE ${SDL_gpu_public_HDRS})
     configure_file(${INC_FILE} ${CMAKE_BINARY_DIR}/${OUTPUT_DIR}/include/${BASE} COPYONLY)
 endforeach(INC_FILE)
 
-configure_file(${CMAKE_SOURCE_DIR}/LICENSE.txt ${CMAKE_BINARY_DIR}/${OUTPUT_DIR}/LICENSE.txt COPYONLY)
-configure_file(${CMAKE_SOURCE_DIR}/README.md ${CMAKE_BINARY_DIR}/${OUTPUT_DIR}/README.md COPYONLY)
+configure_file(../LICENSE.txt ${CMAKE_BINARY_DIR}/${OUTPUT_DIR}/LICENSE.txt COPYONLY)
+configure_file(../README.md ${CMAKE_BINARY_DIR}/${OUTPUT_DIR}/README.md COPYONLY)
 
 # Build the shared library (.so or .dll)
 if(BUILD_SHARED)


### PR DESCRIPTION
I have used SDL_gpu as a dependency in my project that uses CMake by cloning the SDL_gpu repository inside my project. I simply modified some lines in SDL_gpu to let me easily include SDL_gpu (via `add_subdirectory()`), and compile my entire project, along with the library. I am opening this PR in the hopes that other developers may benefit from my work in letting me easily integrate the project with mine.

The modified projects was compiled, as standalone and as part of a larger project, under the following system configuration:

 * CPU: AMD A4-1200
 * GPU: Kabini (Radeon HD 8180)
 * RAM: 2 GB
 * OS: elementaryOS 5.1.3 Hear
 * Compiler: Clang 10

Note that during compilation, there were warnings from the compiler. However, I reckon that those are for different issues.