### PR TITLE
Fix warning in MSVC2019

### DIFF
--- a/src/renderer_GL_common.inl
+++ b/src/renderer_GL_common.inl
@@ -6,6 +6,8 @@ See a particular renderer's *.c file for specifics. */
 #pragma warning(disable: 4514 4711 4710)
 // Disable warning: Spectre mitigation
 #pragma warning(disable: 5045)
+// Disable warning: 'type cast': conversion from 'long' to 'void *' of greater size
+#pragma warning (disable: 4312)
 #endif
 
 #if !defined(GLAPIENTRY)


### PR DESCRIPTION
Fixes: `'type cast': conversion from 'long' to 'void *' of greater size` when casting `intptr_t` to `void*` on line:

```
glVertexAttribPointer(a->attribute.location, a->attribute.format.num_elems_per_value, a->attribute.format.type, a->attribute.format.normalize, a->per_vertex_storage_stride_bytes, (void*)(intptr_t)a->per_vertex_storage_offset_bytes);
```

Apparently the `intptr_t` trick we are doing (to avoid a warning on some platforms?) causes a warning on MSVC2019.