### PR TITLE
Fix a warning about M_PI already being defined

### DIFF
--- a/include/SDL_gpu.h
+++ b/include/SDL_gpu.h
@@ -1,6 +1,9 @@
 #ifndef _SDL_GPU_H__
 #define _SDL_GPU_H__
 
+#define _USE_MATH_DEFINES // So M_PI and company get defined on MSVC when we include math.h
+#include <math.h> // Must be included before SDL.h, otherwise both try to define M_PI and we get a warning
+
 #include "SDL.h"
 #include <stdio.h>
 #include <stdarg.h>

--- a/src/renderer_shapes_GL_common.inl
+++ b/src/renderer_shapes_GL_common.inl
@@ -2,14 +2,6 @@
 See a particular renderer's *.c file for specifics. */
 
 
-#ifndef M_PI
-    #define M_PI 3.14159265358979323846
-#endif
-
-
-
-
-
 // All shapes start this way for setup and so they can access the blit buffer properly
 #define BEGIN_UNTEXTURED(function_name, shape, num_additional_vertices, num_additional_indices) \
 	GPU_CONTEXT_DATA* cdata; \


### PR DESCRIPTION
In MSVC, if `_USE_MATH_DEFINES` was defined project-wide (or before including `SDL_gpu.h`), the previous order of the includes caused a warning because `SDL.h` would define `M_PI` first and then `math.h` would try to define it again. This change makes sure `M_PI` is always defined by `math.h` and not by `SDL.h`.

Note that, with this change, the (yet another) definition of `M_PI `in `renderer_shapes_GL_common.inl` should never be used and can be removed.