### PR TITLE
Store default shader ids

### DIFF
--- a/include/SDL_gpu.h
+++ b/include/SDL_gpu.h
@@ -446,6 +446,12 @@ typedef struct GPU_Context
 	int stored_window_w;
 	int stored_window_h;
 	
+	/*! Shader handles used in the default shader programs */
+	Uint32 default_textured_vertex_shader_id;
+	Uint32 default_textured_fragment_shader_id;
+	Uint32 default_untextured_vertex_shader_id;
+	Uint32 default_untextured_fragment_shader_id;
+	
 	
 	
 	/*! Internal state */

--- a/src/renderer_GL_common.inl
+++ b/src/renderer_GL_common.inl
@@ -1814,6 +1814,8 @@ static GPU_Target* CreateTargetFromWindow(GPU_Renderer* renderer, Uint32 windowI
             return NULL;
         }
 
+        target->context->default_textured_vertex_shader_id = v;
+        target->context->default_textured_fragment_shader_id = f;
         target->context->default_textured_shader_program = p;
 
         // Get locations of the attributes in the shader
@@ -1853,6 +1855,8 @@ static GPU_Target* CreateTargetFromWindow(GPU_Renderer* renderer, Uint32 windowI
 
         glUseProgram(p);
 
+        target->context->default_untextured_vertex_shader_id = v;
+        target->context->default_untextured_fragment_shader_id = f;
         target->context->default_untextured_shader_program = target->context->current_shader_program = p;
 
         // Get locations of the attributes in the shader


### PR DESCRIPTION
So they can be reused in other shader programs created by the user.

This is the solution proposed in #189