### PR TITLE
Fix camera rotation

### DIFF
--- a/src/renderer_GL_common.inl
+++ b/src/renderer_GL_common.inl
@@ -1191,12 +1191,10 @@ static void changeCamera(GPU_Target* target)
 
 static void get_camera_matrix(GPU_Target* target, float* result)
 {
-	float offsetX, offsetY;
+    float offsetX, offsetY;
 
     GPU_MatrixIdentity(result);
 
-    GPU_MatrixTranslate(result, -target->camera.x, -target->camera.y, -target->camera.z);
-    
     if(target->camera.use_centered_origin)
     {
         offsetX = target->w/2.0f;
@@ -1204,11 +1202,16 @@ static void get_camera_matrix(GPU_Target* target, float* result)
         GPU_MatrixTranslate(result, offsetX, offsetY, 0);
     }
     
+    // Always rotate from the camera center
     GPU_MatrixRotate(result, target->camera.angle, 0, 0, 1);
-    GPU_MatrixScale(result, target->camera.zoom_x, target->camera.zoom_y, 1.0f);
     
     if(target->camera.use_centered_origin)
         GPU_MatrixTranslate(result, -offsetX, -offsetY, 0);
+
+    GPU_MatrixTranslate(result, -target->camera.x, -target->camera.y, -target->camera.z);
+
+    GPU_MatrixScale(result, target->camera.zoom_x, target->camera.zoom_y, 1.0f);
+
 }
 
 


### PR DESCRIPTION
Ensure rotation happen after translation, so from the center of the camera, and scale is independent of translation.

Fixes #26, #124 and #133.

I can't think of a use case where the previous order would be desired, but if it is we turn the `use_centered_origin` boolean into an enum and support all different options (more in the line of #133).