### PR TITLE
add GPU_CopyImageFromSurfaceRect

### DIFF
--- a/include/SDL_gpu.h
+++ b/include/SDL_gpu.h
@@ -1373,6 +1373,9 @@ DECLSPEC GPU_TextureHandle SDLCALL GPU_GetTextureHandle(GPU_Image* image);
 /*! Copy SDL_Surface data into a new GPU_Image.  Don't forget to SDL_FreeSurface() the surface and GPU_FreeImage() the image.*/
 DECLSPEC GPU_Image* SDLCALL GPU_CopyImageFromSurface(SDL_Surface* surface);
 
+/*! Like GPU_CopyImageFromSurface but enable to copy only part of the surface.*/
+DECLSPEC GPU_Image* SDLCALL GPU_CopyImageFromSurfaceRect(SDL_Surface* surface, GPU_Rect* surface_rect);
+
 /*! Copy GPU_Target data into a new GPU_Image.  Don't forget to GPU_FreeImage() the image.*/
 DECLSPEC GPU_Image* SDLCALL GPU_CopyImageFromTarget(GPU_Target* target);
 

--- a/include/SDL_gpu_RendererImpl.h
+++ b/include/SDL_gpu_RendererImpl.h
@@ -86,7 +86,7 @@ typedef struct GPU_RendererImpl
 	GPU_bool (SDLCALL *ReplaceImage)(GPU_Renderer* renderer, GPU_Image* image, SDL_Surface* surface, const GPU_Rect* surface_rect);
 	
 	/*! \see GPU_CopyImageFromSurface() */
-	GPU_Image* (SDLCALL *CopyImageFromSurface)(GPU_Renderer* renderer, SDL_Surface* surface);
+	GPU_Image* (SDLCALL *CopyImageFromSurface)(GPU_Renderer* renderer, SDL_Surface* surface, GPU_Rect *surface_rect);
 	
 	/*! \see GPU_CopyImageFromTarget() */
 	GPU_Image* (SDLCALL *CopyImageFromTarget)(GPU_Renderer* renderer, GPU_Target* target);

--- a/src/SDL_gpu.c
+++ b/src/SDL_gpu.c
@@ -990,7 +990,7 @@ GPU_Image* GPU_LoadImage_RW(SDL_RWops* rwops, GPU_bool free_rwops)
         return NULL;
     }
 
-    result = _gpu_current_renderer->impl->CopyImageFromSurface(_gpu_current_renderer, surface);
+    result = _gpu_current_renderer->impl->CopyImageFromSurface(_gpu_current_renderer, surface, NULL);
     SDL_FreeSurface(surface);
 
     return result;
@@ -1307,7 +1307,15 @@ GPU_Image* GPU_CopyImageFromSurface(SDL_Surface* surface)
     if(_gpu_current_renderer == NULL || _gpu_current_renderer->current_context_target == NULL)
         return NULL;
 
-    return _gpu_current_renderer->impl->CopyImageFromSurface(_gpu_current_renderer, surface);
+    return _gpu_current_renderer->impl->CopyImageFromSurface(_gpu_current_renderer, surface, NULL);
+}
+
+GPU_Image* GPU_CopyImageFromSurfaceRect(SDL_Surface* surface, GPU_Rect* surface_rect)
+{
+    if(_gpu_current_renderer == NULL || _gpu_current_renderer->current_context_target == NULL)
+        return NULL;
+
+    return _gpu_current_renderer->impl->CopyImageFromSurface(_gpu_current_renderer, surface, surface_rect);
 }
 
 GPU_Image* GPU_CopyImageFromTarget(GPU_Target* target)

--- a/src/renderer_GL_common.inl
+++ b/src/renderer_GL_common.inl
@@ -3470,14 +3470,14 @@ static GPU_Image* CopyImage(GPU_Renderer* renderer, GPU_Image* image)
 
 static void UpdateImage(GPU_Renderer* renderer, GPU_Image* image, const GPU_Rect* image_rect, SDL_Surface* surface, const GPU_Rect* surface_rect)
 {
-	GPU_IMAGE_DATA* data;
-	GLenum original_format;
+    GPU_IMAGE_DATA* data;
+    GLenum original_format;
 
-	SDL_Surface* newSurface;
-	GPU_Rect updateRect;
-	GPU_Rect sourceRect;
-	int alignment;
-	Uint8* pixels;
+    SDL_Surface* newSurface;
+    GPU_Rect updateRect;
+    GPU_Rect sourceRect;
+    int alignment;
+    Uint8* pixels;
 
     if(image == NULL || surface == NULL)
         return;
@@ -3870,16 +3870,19 @@ static_inline Uint32 getPixel(SDL_Surface *Surface, int x, int y)
     return 0;  // FIXME: Handle errors better
 }
 
-static GPU_Image* CopyImageFromSurface(GPU_Renderer* renderer, SDL_Surface* surface)
+static GPU_Image* CopyImageFromSurface(GPU_Renderer* renderer, SDL_Surface* surface, const GPU_Rect* surface_rect)
 {
     GPU_FormatEnum format;
-	GPU_Image* image;
+    GPU_Image* image;
+    int sw, sh;
 
     if(surface == NULL)
     {
         GPU_PushErrorCode("GPU_CopyImageFromSurface", GPU_ERROR_NULL_ARGUMENT, "surface");
         return NULL;
     }
+    sw = surface_rect == NULL ? surface->w : surface_rect->w;
+    sh = surface_rect == NULL ? surface->h : surface_rect->h;
 
     if(surface->w == 0 || surface->h == 0)
     {
@@ -3901,11 +3904,11 @@ static GPU_Image* CopyImageFromSurface(GPU_Renderer* renderer, SDL_Surface* surf
         format = GPU_FORMAT_RGBA;
     }
 
-    image = renderer->impl->CreateImage(renderer, (Uint16)surface->w, (Uint16)surface->h, format);
+    image = renderer->impl->CreateImage(renderer, (Uint16)sw, (Uint16)sh, format);
     if(image == NULL)
         return NULL;
 
-    renderer->impl->UpdateImage(renderer, image, NULL, surface, NULL);
+    renderer->impl->UpdateImage(renderer, image, NULL, surface, surface_rect);
 
     return image;
 }
@@ -3913,11 +3916,11 @@ static GPU_Image* CopyImageFromSurface(GPU_Renderer* renderer, SDL_Surface* surf
 
 static GPU_Image* CopyImageFromTarget(GPU_Renderer* renderer, GPU_Target* target)
 {
-	GPU_Image* result;
+    GPU_Image* result;
 
     if(target == NULL)
         return NULL;
-    
+
     if(target->image != NULL)
     {
         result = gpu_copy_image_pixels_only(renderer, target->image);
@@ -3925,7 +3928,7 @@ static GPU_Image* CopyImageFromTarget(GPU_Renderer* renderer, GPU_Target* target
     else
     {
         SDL_Surface* surface = renderer->impl->CopySurfaceFromTarget(renderer, target);
-        result = renderer->impl->CopyImageFromSurface(renderer, surface);
+        result = renderer->impl->CopyImageFromSurface(renderer, surface, NULL);
         SDL_FreeSurface(surface);
     }
 


### PR DESCRIPTION
This function is like GPU_CopyImageFromSurface, but enable to copy only part
of the surface to the texture, using an optional pointer to GPU_Rect as
a new argument.

I've also re-indent some code, if you want I can separate it in a new patch ?

Signed-off-by: matthias <uso.cosmo.ray@gmail.com>